### PR TITLE
add mountpoint=legacy

### DIFF
--- a/modules/hosts/zfs/disks/nixos.nix
+++ b/modules/hosts/zfs/disks/nixos.nix
@@ -394,6 +394,7 @@ in
                 type = "zfs_fs";
                 mountpoint = "/storage";
                 options = {
+                  mountpoint = "legacy";
                   atime = "off";
                   canmount = "on";
                   "com.sun:auto-snapshot" = "false";
@@ -403,6 +404,7 @@ in
                 type = "zfs_fs";
                 mountpoint = "/storage/save";
                 options = {
+                  mountpoint = "legacy";
                   atime = "off";
                   canmount = "on";
                   "com.sun:auto-snapshot" = "false";
@@ -412,6 +414,7 @@ in
                 type = "zfs_fs";
                 mountpoint = "/backups";
                 options = {
+                  mountpoint = "legacy";
                   atime = "off";
                   canmount = "on";
                   "com.sun:auto-snapshot" = "false";


### PR DESCRIPTION
Been using this module in my config. It seems that in recent combinations of disko/systemd the latter can attempt to mount `/backups`, `/storage` and `/storage/save` while it was already been mounted by zfs, and fails dropping you into a shell (that sometimes you can just ctrl-d to resume from without issue, but still requires interacting with the server). 

The error you get is "Failed to mount local filesystems" on that target, with lines for each: "Failed to mount /storage", etc.

Thought to share so that a) you don't run into this issue if you ever reinstall b) get your feedback  as to whether this would pose any problems (so far none for me).